### PR TITLE
 ajustes finos

### DIFF
--- a/_includes/apoie.html
+++ b/_includes/apoie.html
@@ -1,16 +1,22 @@
 <div class="container">
 	<div class="row apoie">
-		<div class="col s12 m6 l6">
-			<h4>Apoie nosso evento</h4>
-			<p class="text_justify"> {{site.apoie_description: }} </p>
-			
-			<br/>
-			<a class="waves-effect waves-light btn btn-large" target="_blank" href="https://docs.google.com/presentation/d/e/2PACX-1vTQgdjEKIV1oJqZyB2i1a9OUFu0NcJ1HtN95DJT6WbtK5ovNLW-M4dC_KPb9uFWXqL10m7cfKQ8nbhW/pub">Saiba mais</a>
-		</div>
-		
+
 		<div class="col s12 m6 l6">
 			<img alt="pyladiesbr" src="{{ "/assets/img/apoie_evento_2025.png" | prepend: site.baseurl }}" />
 		</div>
+
+		<div class="col s12 m6 l6">
+			<div class="apoie2">
+				<h4>Apoie nosso evento</h4>
+				<p class="text_justify"> {{site.apoie_description: }} </p>
+				<br/>
+				<a class="waves-effect waves-light btn btn-large" target="_blank" href="https://docs.google.com/presentation/d/e/2PACX-1vTQgdjEKIV1oJqZyB2i1a9OUFu0NcJ1HtN95DJT6WbtK5ovNLW-M4dC_KPb9uFWXqL10m7cfKQ8nbhW/pub">Saiba mais</a>
+			</div>
+			</div>
+		
+		</div>
+		
+		
 
 	</div>
 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
 	<ul class="hide-on-med-and-down">
 	  <li><a href="index.html#sobre">Sobre</a></li>             
 	  <li><a href="index.html#programacao">Programação</a></li>
-	  <li><a href="index.html#inscricoes">Inscrições</a></li>
+	  <li><a href="index.html#inscricoes" href="https://www.even3.com.br/pyladies-br-conference-3-536440/">Inscrições</a></li>
 	  <li><a href="index.html#keynotes">Keynotes</a></li>			  
 	  <li><a href="index.html#palestrantes">Palestrantes</a></li>
 	  <li><a target="_blank" href="https://docs.google.com/document/d/e/2PACX-1vTkVt2ermHYzhgzcqs2VqQGk9PS01UkIXcI0Gjmb_OkBTbdocYGPY2DCrMgmi8N1Dps1WS_KdrF45F2/pub">Código de Conduta</a></li>
@@ -15,7 +15,7 @@
 <ul class="sidenav" id="mobile-demo">
 	<li><a href="index.html#sobre">Sobre</a></li>             
 	<li><a href="index.html#programacao">Programação</a></li>
-	<li><a href="index.html#inscricoes">Inscrições</a></li>
+	<li><a href="index.html#inscricoes" href="https://www.even3.com.br/pyladies-br-conference-3-536440/">Inscrições</a></li>
 	<li><a href="index.html#keynotes">Keynotes</a></li>			  
 	<li><a href="index.html#palestrantes">Palestrantes</a></li>
 	<li><a target="_blank" href="https://docs.google.com/document/d/e/2PACX-1vTkVt2ermHYzhgzcqs2VqQGk9PS01UkIXcI0Gjmb_OkBTbdocYGPY2DCrMgmi8N1Dps1WS_KdrF45F2/pub">Código de Conduta</a></li>

--- a/_includes/local.html
+++ b/_includes/local.html
@@ -1,8 +1,10 @@
 <div class="container">
 	<div class="row local">
 		<div class="col s12 m6 l6">
-			<h4>Local do evento</h4>
-			<p class="text_justify"> {{site.local_description: }} </p>
+			<div class="local2">
+				<h4>Local do evento</h4>
+				<p class="text_justify"> {{site.local_description: }} </p>
+			</div>
 		</div>
 		
 		<div class="col s12 m6 l6">

--- a/_includes/sobre.html
+++ b/_includes/sobre.html
@@ -6,8 +6,10 @@
 		</div>
 
 		<div class="col s12 m6 l6">
-			<h4>Sobre o evento</h4>
-			<p class="text_justify font-montserrat font-light"> {{site.user_description}} </p>
+			<div class="sobre2">
+				<h4>Sobre o evento</h4>
+				<p class="text_justify font-montserrat font-light"> {{site.user_description}} </p>
+			</div>
 		</div>
 
 	</div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -204,3 +204,24 @@ h4 {
   line-height: 110%;
   margin: 1.52rem 0 .912rem 0;
 }
+
+
+@media (min-width: 768px){
+	.sobre2{
+		padding: 10em 0 0;
+	}
+}
+
+
+@media (min-width: 768px){
+	.local2{
+		padding: 10em 0 0;
+	}
+}
+
+
+@media (min-width: 768px){
+	.apoie2{
+		padding:  10em 0 0 6em;
+	}
+}


### PR DESCRIPTION
Revisão do site

1. div de Titulo e Subtitulo de Sobre, local e Apoie ajustar, pois no desktop o bloco ta mt em cima e precisa ficar centralizado

2. Atualizar o apoie - foto a esquerda e titulo e subtitulo a direita. Pra n ficar na mesma direção do bloco de cima

3. Coloquei o link de inscrições 